### PR TITLE
update to only read the condensed catalog once

### DIFF
--- a/dwr-hecdssvue/src/main/java/gov/ca/dwr/hecdssvue/DssPluginCore.java
+++ b/dwr-hecdssvue/src/main/java/gov/ca/dwr/hecdssvue/DssPluginCore.java
@@ -18,8 +18,6 @@ import calsim.gui.DtsTreePanel;
 
 public class DssPluginCore {
 	public static String ID_DSSVue_DSSTableView="gov.ca.dwr.hecdssvue.views.DSSTableView";
-	public static String ID_DSSVue_DSSCatalogView="gov.ca.dwr.hecdssvue.views.DSSCatalogView";
-	public static String ID_DSSVue_DSSMathFunctionView = "gov.ca.dwr.hecdssvue.views.DSSMathFunctionView"; 
 	
 	public static boolean dssEditable=false;
 	

--- a/dwr-hecdssvue/src/main/java/gov/ca/dwr/hecdssvue/components/CatalogListSelection.java
+++ b/dwr-hecdssvue/src/main/java/gov/ca/dwr/hecdssvue/components/CatalogListSelection.java
@@ -107,7 +107,7 @@ public class CatalogListSelection extends ListSelection {
 		
 		IWorkbench workbench=PlatformUI.getWorkbench();
 		IWorkbenchPage workBenchPage = workbench.getActiveWorkbenchWindow().getActivePage();
-		final DSSCatalogView dssCatalogView=(DSSCatalogView) workBenchPage.findView(DssPluginCore.ID_DSSVue_DSSCatalogView);
+		final DSSCatalogView dssCatalogView=(DSSCatalogView) workBenchPage.findView(DSSCatalogView.ID);
 
 		if (dssCatalogView !=null){
 			final Vector<String[]> selectedParts=dssCatalogView.getSelectedParts();			

--- a/dwr-hecdssvue/src/main/java/gov/ca/dwr/hecdssvue/components/DataOps.java
+++ b/dwr-hecdssvue/src/main/java/gov/ca/dwr/hecdssvue/components/DataOps.java
@@ -462,7 +462,7 @@ public class DataOps {
 	public static void deleteSelected(){
 		IWorkbench workbench=PlatformUI.getWorkbench();
 		IWorkbenchPage workBenchPage = workbench.getActiveWorkbenchWindow().getActivePage();
-		DSSCatalogView dssCatalogView=(DSSCatalogView) workBenchPage.findView(DssPluginCore.ID_DSSVue_DSSCatalogView);
+		DSSCatalogView dssCatalogView=(DSSCatalogView) workBenchPage.findView(DSSCatalogView.ID);
 		boolean[] foundInDv={false, false, false, false};
 		
 		if (dssCatalogView !=null){

--- a/dwr-hecdssvue/src/main/java/gov/ca/dwr/hecdssvue/components/DssMathFrame.java
+++ b/dwr-hecdssvue/src/main/java/gov/ca/dwr/hecdssvue/components/DssMathFrame.java
@@ -198,7 +198,7 @@ public class DssMathFrame extends MathFrame2 {
 		final IWorkbench workbench=PlatformUI.getWorkbench();
 		workbench.getDisplay().syncExec(new Runnable(){
 			public void run(){
-				DSSCatalogView dssCatalogView = (DSSCatalogView)workbench.getActiveWorkbenchWindow().getActivePage().findView(DssPluginCore.ID_DSSVue_DSSCatalogView);
+				DSSCatalogView dssCatalogView = (DSSCatalogView)workbench.getActiveWorkbenchWindow().getActivePage().findView(DSSCatalogView.ID);
 				TableViewer viewer = dssCatalogView.getViewer();
 				viewer.setInput(viewer.getInput());
 			}

--- a/dwr-hecdssvue/src/main/java/gov/ca/dwr/hecdssvue/menus/AllowEdit.java
+++ b/dwr-hecdssvue/src/main/java/gov/ca/dwr/hecdssvue/menus/AllowEdit.java
@@ -22,7 +22,7 @@ public class AllowEdit implements IWorkbenchWindowActionDelegate{
 		DssPluginCore.dssEditable=!DssPluginCore.dssEditable;
 		IWorkbench workbench=PlatformUI.getWorkbench();
 		IWorkbenchPage workBenchPage = workbench.getActiveWorkbenchWindow().getActivePage();
-		DSSTableView dssTableView=(DSSTableView) workBenchPage.findView(DssPluginCore.ID_DSSVue_DSSTableView);
+		DSSTableView dssTableView=(DSSTableView) workBenchPage.findView(DSSTableView.ID);
 		
 		if (dssTableView !=null){
 			HecDataTable table = dssTableView.getTable();

--- a/dwr-hecdssvue/src/main/java/gov/ca/dwr/hecdssvue/menus/DuplicateRecords.java
+++ b/dwr-hecdssvue/src/main/java/gov/ca/dwr/hecdssvue/menus/DuplicateRecords.java
@@ -31,7 +31,7 @@ public class DuplicateRecords implements IWorkbenchWindowActionDelegate{
 	public void run(IAction action) {
 		IWorkbench workbench=PlatformUI.getWorkbench();
 		IWorkbenchPage workBenchPage = workbench.getActiveWorkbenchWindow().getActivePage();
-		final DSSCatalogView dssCatalogView=(DSSCatalogView) workBenchPage.findView(DssPluginCore.ID_DSSVue_DSSCatalogView);
+		final DSSCatalogView dssCatalogView=(DSSCatalogView) workBenchPage.findView(DSSCatalogView.ID);
 
 		if (dssCatalogView !=null){
 			final Vector<String[]> selectedParts=dssCatalogView.getSelectedParts();

--- a/dwr-hecdssvue/src/main/java/gov/ca/dwr/hecdssvue/menus/InsertRows.java
+++ b/dwr-hecdssvue/src/main/java/gov/ca/dwr/hecdssvue/menus/InsertRows.java
@@ -20,7 +20,7 @@ public class InsertRows implements IWorkbenchWindowActionDelegate{
 		workbench.getDisplay().asyncExec(new Runnable(){
 			public void run(){
 				IWorkbenchPage workBenchPage = workbench.getActiveWorkbenchWindow().getActivePage();
-				DSSTableView dssTableView=(DSSTableView) workBenchPage.findView(DssPluginCore.ID_DSSVue_DSSTableView);
+				DSSTableView dssTableView=(DSSTableView) workBenchPage.findView(DSSTableView.ID);
 												
 				if (dssTableView !=null){
 					final HecDataTable table = dssTableView.getTable();

--- a/dwr-hecdssvue/src/main/java/gov/ca/dwr/hecdssvue/menus/ManualTimeseries.java
+++ b/dwr-hecdssvue/src/main/java/gov/ca/dwr/hecdssvue/menus/ManualTimeseries.java
@@ -75,7 +75,7 @@ public class ManualTimeseries implements IWorkbenchWindowActionDelegate{
 					    		workbench.getDisplay().syncExec(new Runnable(){
 					    			public void run(){
 					    				IWorkbenchPage workBenchPage = workbench.getActiveWorkbenchWindow().getActivePage();
-										DSSCatalogView dssCatalogView=(DSSCatalogView) workBenchPage.findView(DssPluginCore.ID_DSSVue_DSSCatalogView);
+										DSSCatalogView dssCatalogView=(DSSCatalogView) workBenchPage.findView(DSSCatalogView.ID);
 										TableViewer viewer = dssCatalogView.getViewer();
 										viewer.setInput(viewer.getInput()); 
 					    			}

--- a/dwr-hecdssvue/src/main/java/gov/ca/dwr/hecdssvue/menus/MathFunction.java
+++ b/dwr-hecdssvue/src/main/java/gov/ca/dwr/hecdssvue/menus/MathFunction.java
@@ -26,7 +26,7 @@ public class MathFunction implements IWorkbenchWindowActionDelegate{
 	public void run(IAction action) {
 		IWorkbench workbench=PlatformUI.getWorkbench();
 		IWorkbenchPage workBenchPage = workbench.getActiveWorkbenchWindow().getActivePage();
-		DSSCatalogView dssCatalogView=(DSSCatalogView) workBenchPage.findView(DssPluginCore.ID_DSSVue_DSSCatalogView);
+		DSSCatalogView dssCatalogView=(DSSCatalogView) workBenchPage.findView(DSSCatalogView.ID);
 		
 		if (dssCatalogView !=null){
 			final Vector<String[]> selectedParts=dssCatalogView.getSelectedParts();			

--- a/dwr-hecdssvue/src/main/java/gov/ca/dwr/hecdssvue/menus/RenameRecords.java
+++ b/dwr-hecdssvue/src/main/java/gov/ca/dwr/hecdssvue/menus/RenameRecords.java
@@ -31,7 +31,7 @@ public class RenameRecords implements IWorkbenchWindowActionDelegate{
 	public void run(IAction action) {
 		IWorkbench workbench=PlatformUI.getWorkbench();
 		IWorkbenchPage workBenchPage = workbench.getActiveWorkbenchWindow().getActivePage();
-		final DSSCatalogView dssCatalogView=(DSSCatalogView) workBenchPage.findView(DssPluginCore.ID_DSSVue_DSSCatalogView);
+		final DSSCatalogView dssCatalogView=(DSSCatalogView) workBenchPage.findView(DSSCatalogView.ID);
 
 		if (dssCatalogView !=null){
 			final Vector<String[]> selectedParts=dssCatalogView.getSelectedParts();

--- a/dwr-hecdssvue/src/main/java/gov/ca/dwr/hecdssvue/menus/SaveDss.java
+++ b/dwr-hecdssvue/src/main/java/gov/ca/dwr/hecdssvue/menus/SaveDss.java
@@ -19,7 +19,7 @@ public class SaveDss implements IWorkbenchWindowActionDelegate{
 	public void run(IAction action) {
 		IWorkbench workbench=PlatformUI.getWorkbench();
 		IWorkbenchPage workBenchPage = workbench.getActiveWorkbenchWindow().getActivePage();
-		DSSTableView dssTableView=(DSSTableView) workBenchPage.findView(DssPluginCore.ID_DSSVue_DSSTableView);
+		DSSTableView dssTableView=(DSSTableView) workBenchPage.findView(DSSTableView.ID);
 		
 		if (dssTableView != null){
 			final HecDataTable table = dssTableView.getTable();

--- a/dwr-hecdssvue/src/main/java/gov/ca/dwr/hecdssvue/panel/OpsPanel.java
+++ b/dwr-hecdssvue/src/main/java/gov/ca/dwr/hecdssvue/panel/OpsPanel.java
@@ -281,7 +281,7 @@ public class OpsPanel extends JPanel {
 				workbench.getDisplay().asyncExec(new Runnable(){
 					public void run(){
 						IWorkbenchPage workBenchPage = workbench.getActiveWorkbenchWindow().getActivePage();
-						DSSCatalogView dssCatalogView=(DSSCatalogView) workBenchPage.findView(DssPluginCore.ID_DSSVue_DSSCatalogView);
+						DSSCatalogView dssCatalogView=(DSSCatalogView) workBenchPage.findView(DSSCatalogView.ID);
 						dssCatalogView.getViewer().setInput(DssPluginCore.dssArray);
 					}
 				});
@@ -759,7 +759,7 @@ public class OpsPanel extends JPanel {
 				workbench.getDisplay().asyncExec(new Runnable(){
 					public void run(){
 						IWorkbenchPage workBenchPage = workbench.getActiveWorkbenchWindow().getActivePage();
-						DSSCatalogView dssCatalogView=(DSSCatalogView) workBenchPage.findView(DssPluginCore.ID_DSSVue_DSSCatalogView);
+						DSSCatalogView dssCatalogView=(DSSCatalogView) workBenchPage.findView(DSSCatalogView.ID);
 						dssCatalogView.getViewer().setInput(DssPluginCore.dssArray);
 					}
 				});


### PR DESCRIPTION
Fixes #167

The condensed catalogs were getting read in DSSFileView, then read again in the DSSCatalogView. Rewrote the logic to move the progress indicators into DSSFileView and then only access the cached condensed catalog in DSSCatalogView.

Moving the progress indicators also improves the UX and moves file load off of the UI thread.