### PR TITLE
add optimization to dss catalog read to not pull ts extents

### DIFF
--- a/dwr-hecdssvue/src/main/java/gov/ca/dwr/hecdssvue/components/DataOps.java
+++ b/dwr-hecdssvue/src/main/java/gov/ca/dwr/hecdssvue/components/DataOps.java
@@ -29,6 +29,7 @@ import gov.ca.dwr.hecdssvue.dts.AppUtils;
 import gov.ca.dwr.hecdssvue.dts.Project;
 import wrimsv2_plugin.debugger.core.DebugCorePlugin;
 import wrimsv2_plugin.debugger.exception.WPPException;
+import wrimsv2_plugin.tools.DssUtil;
 
 public class DataOps {
 
@@ -415,8 +416,8 @@ public class DataOps {
 	}
 	
 	public static HashMap<String, String> generatePathnameMap(HecDss file, int j){
-		HashMap<String, String> pathnameMap=new HashMap<String, String> ();
-		Vector<CondensedReference> v=file.getCondensedCatalog();
+		HashMap<String, String> pathnameMap=new HashMap<> ();
+		Vector<CondensedReference> v = DssUtil.getCondensedReferences(file);
 		for (int i=0; i<v.size(); i++){
 			CondensedReference cr = v.get(i);
 			String pathname=cr.getNominalPathname();

--- a/dwr-hecdssvue/src/main/java/gov/ca/dwr/hecdssvue/views/DSSFileView.java
+++ b/dwr-hecdssvue/src/main/java/gov/ca/dwr/hecdssvue/views/DSSFileView.java
@@ -1,16 +1,11 @@
 package gov.ca.dwr.hecdssvue.views;
 
-import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.toList;
 
 import gov.ca.dwr.hecdssvue.Activator;
 import gov.ca.dwr.hecdssvue.DssPluginCore;
 import gov.ca.dwr.hecdssvue.components.DataOps;
-import hec.heclib.dss.CondensedReference;
 import hec.heclib.dss.HecDss;
-
-import java.util.ArrayList;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
@@ -19,12 +14,8 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.LineNumberReader;
 import java.io.PrintWriter;
-
-import java.util.Collection;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.Vector;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.IntStream;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -48,17 +39,17 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.FileDialog;
+import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.MessageBox;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Text;
-import org.eclipse.swt.widgets.Label;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.part.ViewPart;
 import org.eclipse.ui.statushandlers.StatusManager;
-
 import wrimsv2_plugin.debugger.core.DebugCorePlugin;
 import wrimsv2_plugin.debugger.exception.WPPException;
+import wrimsv2_plugin.tools.DssUtil;
 
 public class DSSFileView extends ViewPart {
 
@@ -453,7 +444,7 @@ public class DSSFileView extends ViewPart {
 					subMonitor.setTaskName("Reading DV DSS File " + DebugCorePlugin.studyDvFileNames[i]);
 					HecDss hecDss = HecDss.open(DebugCorePlugin.studyDvFileNames[i]);
 					DebugCorePlugin.dvDss[i] = hecDss;
-					DebugCorePlugin.dvVector[i] = hecDss.getCondensedCatalog();
+					DebugCorePlugin.dvVector[i] = DssUtil.getCondensedReferences(hecDss);
 				} catch (Exception e) {
 					WPPException.handleException(e);
 					errorFiles.add(DebugCorePlugin.studyDvFileNames[i]);
@@ -463,7 +454,7 @@ public class DSSFileView extends ViewPart {
 					subMonitor.setTaskName("Reading SV DSS File " + DebugCorePlugin.studySvFileNames[i]);
 					HecDss hecDss = HecDss.open(DebugCorePlugin.studySvFileNames[i]);
 					DebugCorePlugin.svDss[i] = hecDss;
-					DebugCorePlugin.svVector[i] = hecDss.getCondensedCatalog();
+					DebugCorePlugin.svVector[i] = DssUtil.getCondensedReferences(hecDss);
 				} catch (Exception e) {
 					WPPException.handleException(e);
 					errorFiles.add(DebugCorePlugin.studySvFileNames[i]);

--- a/dwr-hecdssvue/src/main/java/gov/ca/dwr/hecdssvue/views/WaterYearView.java
+++ b/dwr-hecdssvue/src/main/java/gov/ca/dwr/hecdssvue/views/WaterYearView.java
@@ -31,8 +31,8 @@ import org.eclipse.ui.part.ViewPart;
 
 import wrimsv2_plugin.debugger.core.DebugCorePlugin;
 import wrimsv2_plugin.debugger.exception.WPPException;
-//import wrimsv2_plugin.tools.DssOperations;
 import wrimsv2_plugin.tools.DssOperations;
+import wrimsv2_plugin.tools.DssUtil;
 
 public class WaterYearView extends ViewPart {
 
@@ -413,7 +413,7 @@ public class WaterYearView extends ViewPart {
 		if (DssPluginCore.dssArray.size()==0) return;
 		HecDss dss = DssPluginCore.dssArray.get(0);
 		if (dss == null) return;
-		Vector<CondensedReference> dvVector = dss.getCondensedCatalog();
+		Vector<CondensedReference> dvVector = DssUtil.getCondensedReferences(dss);
 		String sacn=DssOperations.matchPathName(dvVector, "WYT_SAC_", "WATERYEARTYPE", "1MON");
 		if (sacn!=null){
 			try {

--- a/jdiagram/src/main/java/gov/ca/dwr/jdiagram/views/SchematicBase.java
+++ b/jdiagram/src/main/java/gov/ca/dwr/jdiagram/views/SchematicBase.java
@@ -81,6 +81,7 @@ import org.eclipse.ui.views.properties.PropertyDescriptor;
 
 import wrimsv2_plugin.debugger.core.DebugCorePlugin;
 import wrimsv2_plugin.debugger.exception.WPPException;
+import wrimsv2_plugin.tools.DssUtil;
 import wrimsv2_plugin.tools.TimeOperation;
 
 import com.mindfusion.diagramming.AttachToNode;
@@ -1795,7 +1796,7 @@ public abstract class SchematicBase extends ViewPart {
 	
 	public static HashMap<String, String> generatePathnameMap(HecDss file){
 		HashMap<String, String> pathnameMap=new HashMap<String, String> ();
-		Vector<CondensedReference> v=file.getCondensedCatalog();
+		Vector<CondensedReference> v = DssUtil.getCondensedReferences(file);
 		for (int i=0; i<v.size(); i++){
 			CondensedReference cr = v.get(i);
 			String pathname=cr.getNominalPathname();

--- a/wrims-ide/src/main/java/wrimsv2_plugin/debugger/dialog/WPPLoadStudyDssDialog.java
+++ b/wrims-ide/src/main/java/wrimsv2_plugin/debugger/dialog/WPPLoadStudyDssDialog.java
@@ -35,6 +35,7 @@ import wrimsv2_plugin.debugger.exception.WPPException;
 import wrimsv2_plugin.debugger.view.WPPVariableView;
 import wrimsv2_plugin.debugger.view.WPPWatchView;
 import wrimsv2_plugin.tools.DataProcess;
+import wrimsv2_plugin.tools.DssUtil;
 
 public class WPPLoadStudyDssDialog extends Dialog {
 	private Button[] checkBox=new Button[8];
@@ -399,7 +400,7 @@ public class WPPLoadStudyDssDialog extends Dialog {
 			if (DebugCorePlugin.selectedStudies[i]){
 				try {
 					DebugCorePlugin.dvDss[i]=HecDss.open(DebugCorePlugin.studyDvFileNames[i]);
-					DebugCorePlugin.dvVector[i]=DebugCorePlugin.dvDss[i].getCondensedCatalog();
+					DebugCorePlugin.dvVector[i]= DssUtil.getCondensedReferences(DebugCorePlugin.dvDss[i]);
 					DebugCorePlugin.dvDss[i].close();
 				} catch (Exception e) {
 					WPPException.handleException(e);
@@ -408,7 +409,7 @@ public class WPPLoadStudyDssDialog extends Dialog {
 				}
 				try {
 					DebugCorePlugin.svDss[i]=HecDss.open(DebugCorePlugin.studySvFileNames[i]);
-					DebugCorePlugin.svVector[i]=DebugCorePlugin.svDss[i].getCondensedCatalog();
+					DebugCorePlugin.svVector[i]=DssUtil.getCondensedReferences(DebugCorePlugin.svDss[i]);
 					DebugCorePlugin.svDss[i].close();
 				} catch (Exception e) {
 					WPPException.handleException(e);

--- a/wrims-ide/src/main/java/wrimsv2_plugin/tools/DssUtil.java
+++ b/wrims-ide/src/main/java/wrimsv2_plugin/tools/DssUtil.java
@@ -1,0 +1,36 @@
+/*
+ * Water Resource Integrated Modeling System (WRIMS) Copyright (c) 2025.
+ *
+ * WRIMS 2 is copyrighted by the State of California Department of Water Resources.
+ * It is licensed under the Eclipse Public License, Version 1.0.
+ * See Eclipse Public License for more details.
+ */
+
+package wrimsv2_plugin.tools;
+
+import hec.heclib.dss.CondensedReference;
+import hec.heclib.dss.HecDSSUtilities;
+import hec.heclib.dss.HecDss;
+import java.util.Vector;
+
+public final class DssUtil {
+
+    private DssUtil() {
+        throw new AssertionError("Utility class");
+    }
+
+    /**
+     * Optimization done to revert behavior of DSS catalog load to not query the period of record
+     * extends for every record in the catalog. Instead, the nominal pathname will be the start -> end block
+     * If DSS7 or small DSS 6 file, the nominal pathname will be the extents for the D-part.
+     * If using a large DSS6 file, the start/end block will be used as the D-part in the nominal pathname.
+     * @param hecDss dss file reference
+     * @return condensed catalog
+     */
+    public static Vector<CondensedReference> getCondensedReferences(HecDss hecDss) {
+        HecDSSUtilities dataManager = hecDss.getDataManager().getLocalDataManager();
+        String[] sortedCatalog = dataManager.getCatalog(true, null);
+        boolean queryTimes = dataManager.getDssFileVersion() == 7 || sortedCatalog.length < 5000;
+        return dataManager.getCondensedCatalog(sortedCatalog, queryTimes);
+    }
+}


### PR DESCRIPTION
in heclib, the times were only queried on small DSS6 files. For heclib7 and DSS7 the extents are retrieved along with the catalog, making the operation fast. For heclib7 and DSS6, the library was changed to always query the ts extents regardless of size, which is very slow for very large DSS files.

This changes makes the same calls that were done with heclib6 by only conditionally querrying the times.